### PR TITLE
Fix bug in determining page title

### DIFF
--- a/scrape.js
+++ b/scrape.js
@@ -104,7 +104,7 @@
       return;
     }
     pageTitle = this.getTitle();
-    if (pageTitle === "Facebook - Log In or Sign Up") {
+    if (pageTitle === "Facebook – log in or sign up") {
       casper.echo("Attempting to log in...");
       query = {
         email: _env.fb_user,


### PR DESCRIPTION
It seems like facebook has decaptitalized some of the words in the homepage title which was causing `pageTitle == "Facebook - log in or sign up" ` to return false.